### PR TITLE
Move code for getblock

### DIFF
--- a/client/src/client_sync/v17/blockchain.rs
+++ b/client/src/client_sync/v17/blockchain.rs
@@ -9,18 +9,6 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements bitcoind JSON-RPC API method `getblockchaininfo`
-#[macro_export]
-macro_rules! impl_client_v17__getblockchaininfo {
-    () => {
-        impl Client {
-            pub fn get_blockchain_info(&self) -> Result<GetBlockchainInfo> {
-                self.call("getblockchaininfo", &[])
-            }
-        }
-    };
-}
-
 /// Implements bitcoind JSON-RPC API method `getbestblockhash`
 #[macro_export]
 macro_rules! impl_client_v17__getbestblockhash {
@@ -65,6 +53,18 @@ macro_rules! impl_client_v17__getblock {
                 hash: &BlockHash,
             ) -> Result<GetBlockVerbosityOne> {
                 self.call("getblock", &[into_json(hash)?, 1.into()])
+            }
+        }
+    };
+}
+
+/// Implements bitcoind JSON-RPC API method `getblockchaininfo`
+#[macro_export]
+macro_rules! impl_client_v17__getblockchaininfo {
+    () => {
+        impl Client {
+            pub fn get_blockchain_info(&self) -> Result<GetBlockchainInfo> {
+                self.call("getblockchaininfo", &[])
             }
         }
     };

--- a/integration_test/src/v17/blockchain.rs
+++ b/integration_test/src/v17/blockchain.rs
@@ -5,19 +5,6 @@
 //! Specifically this is methods found under the `== Blockchain ==` section of the
 //! API docs of `bitcoind v0.17.1`.
 
-/// Requires `Client` to be in scope and to implement `get_blockchain_info`.
-#[macro_export]
-macro_rules! impl_test_v17__getblockchaininfo {
-    () => {
-        #[test]
-        fn get_blockchain_info() {
-            let bitcoind = $crate::bitcoind_no_wallet();
-            let json = bitcoind.client.get_blockchain_info().expect("getblockchaininfo");
-            assert!(json.into_model().is_ok());
-        }
-    };
-}
-
 /// Requires `Client` to be in scope and to implement `get_best_block_hash`.
 #[macro_export]
 macro_rules! impl_test_v17__getbestblockhash {
@@ -77,6 +64,19 @@ macro_rules! impl_test_v17__getblock_verbosity_2 {
 
             let json = client.get_block_verbosity_two(&block_hash).expect("getblock 2");
             json.into_model().unwrap();
+        }
+    };
+}
+
+/// Requires `Client` to be in scope and to implement `get_blockchain_info`.
+#[macro_export]
+macro_rules! impl_test_v17__getblockchaininfo {
+    () => {
+        #[test]
+        fn get_blockchain_info() {
+            let bitcoind = $crate::bitcoind_no_wallet();
+            let json = bitcoind.client.get_blockchain_info().expect("getblockchaininfo");
+            assert!(json.into_model().is_ok());
         }
     };
 }

--- a/integration_test/tests/v17_api.rs
+++ b/integration_test/tests/v17_api.rs
@@ -8,10 +8,10 @@ use integration_test::*;
 mod blockchain {
     use super::*;
 
-    impl_test_v17__getblockchaininfo!();
     impl_test_v17__getbestblockhash!();
     impl_test_v17__getblock_verbosity_0!();
     impl_test_v17__getblock_verbosity_1!();
+    impl_test_v17__getblockchaininfo!();
 }
 
 // == Control ==

--- a/integration_test/tests/v18_api.rs
+++ b/integration_test/tests/v18_api.rs
@@ -8,10 +8,10 @@ use integration_test::*;
 mod blockchain {
     use super::*;
 
-    impl_test_v17__getblockchaininfo!();
     impl_test_v17__getbestblockhash!();
     impl_test_v17__getblock_verbosity_0!();
     impl_test_v17__getblock_verbosity_1!();
+    impl_test_v17__getblockchaininfo!();
 }
 
 // == Control ==

--- a/integration_test/tests/v19_api.rs
+++ b/integration_test/tests/v19_api.rs
@@ -8,10 +8,10 @@ use integration_test::*;
 mod blockchain {
     use super::*;
 
-    impl_test_v17__getblockchaininfo!();
     impl_test_v17__getbestblockhash!();
     impl_test_v17__getblock_verbosity_0!();
     impl_test_v17__getblock_verbosity_1!();
+    impl_test_v17__getblockchaininfo!();
 }
 
 // == Control ==

--- a/integration_test/tests/v20_api.rs
+++ b/integration_test/tests/v20_api.rs
@@ -8,10 +8,10 @@ use integration_test::*;
 mod blockchain {
     use super::*;
 
-    impl_test_v17__getblockchaininfo!();
     impl_test_v17__getbestblockhash!();
     impl_test_v17__getblock_verbosity_0!();
     impl_test_v17__getblock_verbosity_1!();
+    impl_test_v17__getblockchaininfo!();
 }
 
 // == Control ==

--- a/integration_test/tests/v21_api.rs
+++ b/integration_test/tests/v21_api.rs
@@ -8,10 +8,10 @@ use integration_test::*;
 mod blockchain {
     use super::*;
 
-    impl_test_v17__getblockchaininfo!();
     impl_test_v17__getbestblockhash!();
     impl_test_v17__getblock_verbosity_0!();
     impl_test_v17__getblock_verbosity_1!();
+    impl_test_v17__getblockchaininfo!();
 }
 
 // == Control ==

--- a/integration_test/tests/v22_api.rs
+++ b/integration_test/tests/v22_api.rs
@@ -8,10 +8,10 @@ use integration_test::*;
 mod blockchain {
     use super::*;
 
-    impl_test_v17__getblockchaininfo!();
     impl_test_v17__getbestblockhash!();
     impl_test_v17__getblock_verbosity_0!();
     impl_test_v17__getblock_verbosity_1!();
+    impl_test_v17__getblockchaininfo!();
 }
 
 // == Control ==

--- a/integration_test/tests/v23_api.rs
+++ b/integration_test/tests/v23_api.rs
@@ -8,10 +8,10 @@ use integration_test::*;
 mod blockchain {
     use super::*;
 
-    impl_test_v17__getblockchaininfo!();
     impl_test_v17__getbestblockhash!();
     impl_test_v17__getblock_verbosity_0!();
     impl_test_v17__getblock_verbosity_1!();
+    impl_test_v17__getblockchaininfo!();
 }
 
 // == Control ==

--- a/integration_test/tests/v24_api.rs
+++ b/integration_test/tests/v24_api.rs
@@ -8,10 +8,10 @@ use integration_test::*;
 mod blockchain {
     use super::*;
 
-    impl_test_v17__getblockchaininfo!();
     impl_test_v17__getbestblockhash!();
     impl_test_v17__getblock_verbosity_0!();
     impl_test_v17__getblock_verbosity_1!();
+    impl_test_v17__getblockchaininfo!();
 }
 
 // == Control ==

--- a/integration_test/tests/v25_api.rs
+++ b/integration_test/tests/v25_api.rs
@@ -8,10 +8,10 @@ use integration_test::*;
 mod blockchain {
     use super::*;
 
-    impl_test_v17__getblockchaininfo!();
     impl_test_v17__getbestblockhash!();
     impl_test_v17__getblock_verbosity_0!();
     impl_test_v17__getblock_verbosity_1!();
+    impl_test_v17__getblockchaininfo!();
 }
 
 // == Control ==

--- a/integration_test/tests/v26_api.rs
+++ b/integration_test/tests/v26_api.rs
@@ -8,10 +8,10 @@ use integration_test::*;
 mod blockchain {
     use super::*;
 
-    impl_test_v17__getblockchaininfo!();
     impl_test_v17__getbestblockhash!();
     impl_test_v17__getblock_verbosity_0!();
     impl_test_v17__getblock_verbosity_1!();
+    impl_test_v17__getblockchaininfo!();
 }
 
 // == Control ==

--- a/integration_test/tests/v27_api.rs
+++ b/integration_test/tests/v27_api.rs
@@ -8,10 +8,10 @@ use integration_test::*;
 mod blockchain {
     use super::*;
 
-    impl_test_v17__getblockchaininfo!();
     impl_test_v17__getbestblockhash!();
     impl_test_v17__getblock_verbosity_0!();
     impl_test_v17__getblock_verbosity_1!();
+    impl_test_v17__getblockchaininfo!();
 }
 
 // == Control ==

--- a/json/src/model/blockchain.rs
+++ b/json/src/model/blockchain.rs
@@ -17,6 +17,53 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct GetBestBlockHash(pub BlockHash);
 
+/// Models the result of JSON-RPC method `getblock` with verbosity set to 0.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct GetBlockVerbosityZero(pub Block);
+
+/// Models the result of JSON-RPC method `getblock` with verbosity set to 1.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct GetBlockVerbosityOne {
+    /// The block hash (same as provided) in RPC call.
+    pub hash: BlockHash,
+    /// The number of confirmations, or -1 if the block is not on the main chain.
+    pub confirmations: i32,
+    /// The block size.
+    pub size: usize,
+    /// The block size excluding witness data.
+    pub stripped_size: Option<usize>, // Weight?
+    /// The block weight as defined in BIP-141.
+    pub weight: Weight,
+    /// The block height or index.
+    pub height: usize,
+    /// The block version.
+    pub version: block::Version,
+    /// The block version formatted in hexadecimal.
+    pub version_hex: String,
+    /// The merkle root.
+    pub merkle_root: String,
+    /// The transaction ids.
+    pub tx: Vec<Txid>,
+    /// The block time expressed in UNIX epoch time.
+    pub time: usize,
+    /// The median block time expressed in UNIX epoch time.
+    pub median_time: Option<usize>,
+    /// The nonce.
+    pub nonce: u32,
+    /// The bits.
+    pub bits: CompactTarget,
+    /// The difficulty.
+    pub difficulty: f64,
+    /// Expected number of hashes required to produce the chain up to this block (in hex).
+    pub chain_work: Work,
+    /// The number of transactions in the block.
+    pub n_tx: u32,
+    /// The hash of the previous block (if available).
+    pub previous_block_hash: Option<BlockHash>,
+    /// The hash of the next block (if available).
+    pub next_block_hash: Option<BlockHash>,
+}
+
 /// Models the result of JSON-RPC method `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct GetBlockchainInfo {
@@ -127,53 +174,6 @@ pub struct Bip9SoftforkStatistics {
     pub count: u32,
     /// `false` if there are not enough blocks left in this period to pass activation threshold.
     pub possible: Option<bool>,
-}
-
-/// Models the result of JSON-RPC method `getblock` with verbosity set to 0.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct GetBlockVerbosityZero(pub Block);
-
-/// Models the result of JSON-RPC method `getblock` with verbosity set to 1.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct GetBlockVerbosityOne {
-    /// The block hash (same as provided) in RPC call.
-    pub hash: BlockHash,
-    /// The number of confirmations, or -1 if the block is not on the main chain.
-    pub confirmations: i32,
-    /// The block size.
-    pub size: usize,
-    /// The block size excluding witness data.
-    pub stripped_size: Option<usize>, // Weight?
-    /// The block weight as defined in BIP-141.
-    pub weight: Weight,
-    /// The block height or index.
-    pub height: usize,
-    /// The block version.
-    pub version: block::Version,
-    /// The block version formatted in hexadecimal.
-    pub version_hex: String,
-    /// The merkle root.
-    pub merkle_root: String,
-    /// The transaction ids.
-    pub tx: Vec<Txid>,
-    /// The block time expressed in UNIX epoch time.
-    pub time: usize,
-    /// The median block time expressed in UNIX epoch time.
-    pub median_time: Option<usize>,
-    /// The nonce.
-    pub nonce: u32,
-    /// The bits.
-    pub bits: CompactTarget,
-    /// The difficulty.
-    pub difficulty: f64,
-    /// Expected number of hashes required to produce the chain up to this block (in hex).
-    pub chain_work: Work,
-    /// The number of transactions in the block.
-    pub n_tx: u32,
-    /// The hash of the previous block (if available).
-    pub previous_block_hash: Option<BlockHash>,
-    /// The hash of the next block (if available).
-    pub next_block_hash: Option<BlockHash>,
 }
 
 /// Models the result of JSON-RPC method `gettxout`.


### PR DESCRIPTION
Seems that we added the `getblock` stuff in the order we implemented it instead of in some sane order.

Move the code for `getblock` so it is in the same order in code as it is listed in the `rpc-api.txt` file.

Code move only, no other changes.