### PR TITLE
Fix clippy line-too-long warning

### DIFF
--- a/jsonrpc/src/http/simple_http.rs
+++ b/jsonrpc/src/http/simple_http.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
 //! This module implements a minimal and non standard conforming HTTP 1.0
-//! round-tripper that works with the bitcoind RPC server. This can be used
-//! if minimal dependencies are a goal and synchronous communication is ok.
+//! round-tripper that works with the bitcoind RPC server.
+//!
+//! This can be used if minimal dependencies are a goal and
+//! synchronous communication is ok.
 
 use std::io::{BufRead, BufReader, Read, Write};
 #[cfg(not(jsonrpc_fuzz))]


### PR DESCRIPTION
clippy emits:

 warning: first doc comment paragraph is too long

Separate the two sentences so the first line is not too long.