### PR TITLE
jsonrpc: Actually bump the MSRV

### DIFF
--- a/jsonrpc/Cargo.toml
+++ b/jsonrpc/Cargo.toml
@@ -10,7 +10,7 @@ description = "Rust support for the JSON-RPC 2.0 protocol"
 keywords = [ "protocol", "json", "http", "jsonrpc" ]
 readme	 = "README.md"
 edition = "2021"
-rust-version = "1.56.1"
+rust-version = "1.63.0"
 exclude = ["tests", "contrib"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Before we migrated the `jsonrpc` crate into this repo I did a PR to bump the MSRV that was merged [0] in which I did not actually update the `rust-version` in the manifest - face palm.

[0] https://github.com/apoelstra/rust-jsonrpc/pull/125