### PR TITLE
v17: Add support for control methods

### DIFF
--- a/client/src/client_sync/v17/control.rs
+++ b/client/src/client_sync/v17/control.rs
@@ -9,12 +9,44 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
+/// Implements bitcoind JSON-RPC API method `getmemory`
+#[macro_export]
+macro_rules! impl_client_v17__getmemoryinfo {
+    () => {
+        impl Client {
+            pub fn get_memory_info(&self) -> Result<GetMemoryInfoStats> {
+                self.call("getmemoryinfo", &[])
+            }
+        }
+    };
+}
+
+/// Implements bitcoind JSON-RPC API method `logging`
+#[macro_export]
+macro_rules! impl_client_v17__logging {
+    () => {
+        impl Client {
+            pub fn logging(&self) -> Result<Logging> { self.call("logging", &[]) }
+        }
+    };
+}
+
 /// Implements bitcoind JSON-RPC API method `stop`
 #[macro_export]
 macro_rules! impl_client_v17__stop {
     () => {
         impl Client {
             pub fn stop(&self) -> Result<String> { self.call("stop", &[]) }
+        }
+    };
+}
+
+/// Implements bitcoind JSON-RPC API method `uptime`
+#[macro_export]
+macro_rules! impl_client_v17__uptime {
+    () => {
+        impl Client {
+            pub fn uptime(&self) -> Result<u32> { self.call("uptime", &[]) }
         }
     };
 }

--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -27,7 +27,10 @@ crate::impl_client_v17__getblock!();
 crate::impl_client_v17__gettxout!();
 
 // == Control ==
+crate::impl_client_v17__getmemoryinfo!();
+crate::impl_client_v17__logging!();
 crate::impl_client_v17__stop!();
+crate::impl_client_v17__uptime!();
 
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();

--- a/integration_test/src/v17/control.rs
+++ b/integration_test/src/v17/control.rs
@@ -5,6 +5,32 @@
 //! Specifically this is methods found under the `== Control ==` section of the
 //! API docs of `bitcoind v0.17.1`.
 
+/// Requires `Client` to be in scope and to implement `getmemoryinfo`.
+#[macro_export]
+macro_rules! impl_test_v17__getmemoryinfo {
+    () => {
+        #[test]
+        fn get_memory_info() {
+            let bitcoind = $crate::bitcoind_no_wallet();
+            // There is no model for `getmemoryinfo`, just check we can make the call.
+            let _ = bitcoind.client.get_memory_info().expect("getmemoryinfo");
+        }
+    };
+}
+
+/// Requires `Client` to be in scope and to implement `logging`.
+#[macro_export]
+macro_rules! impl_test_v17__logging {
+    () => {
+        #[test]
+        fn logging() {
+            let bitcoind = $crate::bitcoind_no_wallet();
+            // There is no model for `logging`, just check we can make the call.
+            let _ = bitcoind.client.logging().expect("logging");
+        }
+    };
+}
+
 /// Requires `Client` to be in scope and to implement `stop`.
 #[macro_export]
 macro_rules! impl_test_v17__stop {
@@ -14,6 +40,19 @@ macro_rules! impl_test_v17__stop {
             let bitcoind = $crate::bitcoind_no_wallet();
             // There is no json object for `stop`, we just return a string.
             let _ = bitcoind.client.stop().expect("stop");
+        }
+    };
+}
+
+/// Requires `Client` to be in scope and to implement `uptime`.
+#[macro_export]
+macro_rules! impl_test_v17__uptime {
+    () => {
+        #[test]
+        fn uptime() {
+            let bitcoind = $crate::bitcoind_no_wallet();
+            // There is no json object for `stop`, we just return a int.
+            let _ = bitcoind.client.uptime().expect("uptime");
         }
     };
 }

--- a/integration_test/tests/v17_api.rs
+++ b/integration_test/tests/v17_api.rs
@@ -18,7 +18,10 @@ mod blockchain {
 mod control {
     use super::*;
 
+    impl_test_v17__getmemoryinfo!();
+    impl_test_v17__logging!();
     impl_test_v17__stop!();
+    impl_test_v17__uptime!();
 }
 
 // == Generating ==

--- a/json/src/v17/control.rs
+++ b/json/src/v17/control.rs
@@ -3,3 +3,85 @@
 //! The JSON-RPC API for Bitcoin Core v0.17.1 - control.
 //!
 //! Types for methods found under the `== Control ==` section of the API docs.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Result of JSON-RPC method `getmemoryinfo`.
+///
+/// We only support the default "stats" mode.
+///
+/// > getmemoryinfo ("mode")
+///
+/// > Returns an object containing information about memory usage.
+///
+/// > Arguments:
+/// > 1. "mode" determines what kind of information is returned. This argument is optional, the default mode is "stats".
+/// >   - "stats" returns general statistics about memory usage in the daemon.
+/// >   - "mallocinfo" returns an XML string describing low-level heap state (only available if compiled with glibc 2.10+).
+// This just mimics the map returned by my instance of Core v0.17.1, I don't know how
+// to handle other map values or if they exist?
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct GetMemoryInfoStats(pub HashMap<String, Locked>);
+
+/// Information about locked memory manager.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct Locked {
+    /// Number of bytes used.
+    pub used: u64,
+    /// Number of bytes available in current arenas.
+    pub free: u64,
+    /// Total number of bytes managed.
+    pub total: u64,
+    /// Amount of bytes that succeeded locking.
+    ///
+    /// If this number is smaller than total, locking pages failed at some point and key data could
+    /// be swapped to disk.
+    pub locked: u64,
+    /// Number allocated chunks.
+    pub chunks_used: u64,
+    /// Number unused chunks.
+    pub chunks_free: u64,
+}
+
+/// Result of JSON-RPC method `logging`.
+///
+/// > logging ( `<include>` `<exclude>` )
+///
+/// > Gets and sets the logging configuration.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct Logging {
+    pub net: bool,
+    pub tor: bool,
+    pub mempool: bool,
+    pub http: bool,
+    pub bench: bool,
+    pub zmq: bool,
+    pub db: bool,
+    pub rpc: bool,
+    pub estimatefee: bool,
+    pub addrman: bool,
+    pub selectcoins: bool,
+    pub reindex: bool,
+    pub cmpctblock: bool,
+    pub rand: bool,
+    pub prune: bool,
+    pub proxy: bool,
+    pub mempoolrej: bool,
+    pub libevent: bool,
+    pub coindb: bool,
+    pub qt: bool,
+    pub leveldb: bool,
+}
+
+/// Result of JSON-RPC method `uptime`.
+///
+/// > uptime
+/// >
+/// > Returns the total uptime of the server.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct Uptime {
+    /// The number of seconds that the server has been running.
+    ttt: u32,
+}

--- a/json/src/v17/mod.rs
+++ b/json/src/v17/mod.rs
@@ -34,11 +34,11 @@
 //! - [ ] `verifytxoutproof "proof"`
 //!
 //! **== Control ==**
-//! - [ ] `getmemoryinfo ("mode")`
-//! - [ ] `help ( "command" )`
-//! - [ ] `logging ( <include> <exclude> )`
+//! - [x] `getmemoryinfo ("mode")`
+//! - [-] `help ( "command" )`
+//! - [x] `logging ( <include> <exclude> )`
 //! - [x] `stop`
-//! - [ ] `uptime`
+//! - [x] `uptime`
 //!
 //! **== Generating ==**
 //! - [x] `generate nblocks ( maxtries )`
@@ -169,6 +169,7 @@ pub use self::{
         Bip9Softfork, Bip9SoftforkStatus, GetBestBlockHash, GetBlockVerbosityOne,
         GetBlockVerbosityZero, GetBlockchainInfo, GetTxOut, ScriptPubkey, Softfork, SoftforkReject,
     },
+    control::{GetMemoryInfoStats, Locked, Logging, Uptime},
     generating::{Generate, GenerateToAddress},
     network::{GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork},
     raw_transactions::SendRawTransaction,


### PR DESCRIPTION
Add support for all the JSONRPC methods under the "control" section of the docs.

Note, I'm unsure about the map returned by `getmemoryinfo` in default mode, integration tests show that the "locked" key is parsed correctly.