### PR TITLE
WIP: Track `rust-bitcoin` master branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,53 @@ path = "json"
 
 [patch.crates-io.jsonrpc]
 path = "jsonrpc"
+
+
+[patch.crates-io.base58ck]
+path = "../../rust-bitcoin/10-18-consensus-error/base58"
+
+[patch.crates-io.bitcoin]
+path = "../../rust-bitcoin/10-18-consensus-error/bitcoin"
+
+[patch.crates-io.bitcoin_hashes]
+path = "../../rust-bitcoin/10-18-consensus-error/hashes"
+
+[patch.crates-io.bitcoin-internals]
+path = "../../rust-bitcoin/10-18-consensus-error/internals"
+
+[patch.crates-io.bitcoin-io]
+path = "../../rust-bitcoin/10-18-consensus-error/io"
+
+[patch.crates-io.bitcoin-primitives]
+path = "../../rust-bitcoin/10-18-consensus-error/primitives"
+
+[patch.crates-io.bitcoin-units]
+path = "../../rust-bitcoin/10-18-consensus-error/units"
+
+# [patch.crates-io.base58ck]
+# git = "https://github.com/tcharding/rust-bitcoin"
+# branch = "10-16-set-version-to-alpha"
+
+# [patch.crates-io.bitcoin]
+# git = "https://github.com/tcharding/rust-bitcoin"
+# branch = "10-16-set-version-to-alpha"
+
+# [patch.crates-io.bitcoin_hashes]
+# git = "https://github.com/tcharding/rust-bitcoin"
+# branch = "10-16-set-version-to-alpha"
+
+# [patch.crates-io.bitcoin-internals]
+# git = "https://github.com/tcharding/rust-bitcoin"
+# branch = "10-16-set-version-to-alpha"
+
+# [patch.crates-io.bitcoin-io]
+# git = "https://github.com/tcharding/rust-bitcoin"
+# branch = "10-16-set-version-to-alpha"
+
+# [patch.crates-io.bitcoin-primitives]
+# git = "https://github.com/tcharding/rust-bitcoin"
+# branch = "10-16-set-version-to-alpha"
+
+# [patch.crates-io.bitcoin-units]
+# git = "https://github.com/tcharding/rust-bitcoin"
+# branch = "10-16-set-version-to-alpha"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -26,7 +26,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 client-sync = ["jsonrpc"]
 
 [dependencies]
-bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
+bitcoin = { version = "0.33.0-alpha", default-features = false, features = ["std", "serde"] }
 json = { package = "bitcoind-json-rpc-types", version = "0.3.0", default-features = false, features = [] }
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -50,7 +50,7 @@ edition = "2021"
 "v17" = []
 
 [dependencies]
-bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
+bitcoin = { version = "0.33.0-alpha", default-features = false, features = ["std", "serde"] }
 client = { package = "bitcoind-json-rpc-client", version = "0.3.0", default-features = false, features = ["client-sync"] }
 bitcoind = { package = "bitcoind-json-rpc-regtest", version = "0.3.0", default-features = false, features = [] }
 rand = "0.8.5"
@@ -66,3 +66,32 @@ path = "../json"
 
 [patch.crates-io.bitcoind-json-rpc-regtest]
 path = "../regtest"
+
+
+[patch.crates-io.base58ck]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"
+
+[patch.crates-io.bitcoin]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"
+
+[patch.crates-io.bitcoin_hashes]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"
+
+[patch.crates-io.bitcoin-internals]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"
+
+[patch.crates-io.bitcoin-io]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"
+
+[patch.crates-io.bitcoin-primitives]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"
+
+[patch.crates-io.bitcoin-units]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -21,8 +21,8 @@ exclude = ["tests", "contrib"]
 default = []
 
 [dependencies]
-bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-internals = { package = "bitcoin-internals", version = "0.3.0", default-features = false,  features = ["std"] }
+bitcoin = { version = "0.33.0-alpha", default-features = false, features = ["std", "serde"] }
+internals = { package = "bitcoin-internals", version = "0.4.0", default-features = false,  features = ["std"] }
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -82,4 +82,3 @@ fn btc_per_kb(btc_per_kb: f64) -> Result<Option<FeeRate>, ParseAmountError> {
 
     Ok(rate)
 }
-

--- a/json/src/v17/blockchain.rs
+++ b/json/src/v17/blockchain.rs
@@ -9,8 +9,10 @@ use std::fmt;
 use std::str::FromStr;
 
 use bitcoin::consensus::encode;
-use bitcoin::error::UnprefixedHexError;
 use bitcoin::hex::FromHex;
+use bitcoin::parse::UnprefixedHexError;
+use bitcoin::pow::CompactTargetExt as _;
+use bitcoin::script::ScriptBufExt as _;
 use bitcoin::{
     address, amount, block, hex, network, Address, Amount, Block, BlockHash, CompactTarget,
     FeeRate, Network, ScriptBuf, TxMerkleNode, TxOut, Txid, Weight, Work,
@@ -477,7 +479,7 @@ pub enum GetBlockHeaderError {
     /// Conversion of hex data to bytes failed.
     Hex(hex::HexToBytesError),
     /// Consensus decoding of bytes to header failed.
-    Consensus(encode::Error),
+    Consensus(encode::DeserializeError),
 }
 
 impl fmt::Display for GetBlockHeaderError {

--- a/json/src/v19/blockchain.rs
+++ b/json/src/v19/blockchain.rs
@@ -7,7 +7,7 @@
 use core::fmt;
 use std::collections::BTreeMap;
 
-use bitcoin::error::UnprefixedHexError;
+use bitcoin::parse::UnprefixedHexError;
 use bitcoin::{hex, network, BlockHash, Network, Work};
 use internals::write_err;
 use serde::{Deserialize, Serialize};

--- a/regtest/Cargo.toml
+++ b/regtest/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { version = "1.0.117" }
 env_logger = "0.9.0"
 
 [build-dependencies]
-bitcoin_hashes = { version = ">= 0.13, <= 0.14", optional = true }
+bitcoin_hashes = { version = "0.15", optional = true }
 flate2 = { version = "1.0", optional = true }
 tar = { version = "0.4", optional = true }
 minreq = { version = "2.9.1", default-features = false, features = [
@@ -77,3 +77,32 @@ path = "../client"
 
 [patch.crates-io.bitcoind-json-rpc-types]
 path = "../json"
+
+
+[patch.crates-io.base58ck]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"
+
+[patch.crates-io.bitcoin]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"
+
+[patch.crates-io.bitcoin_hashes]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"
+
+[patch.crates-io.bitcoin-internals]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"
+
+[patch.crates-io.bitcoin-io]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"
+
+[patch.crates-io.bitcoin-primitives]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"
+
+[patch.crates-io.bitcoin-units]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "10-18-consensus-error"

--- a/regtest/build.rs
+++ b/regtest/build.rs
@@ -16,7 +16,7 @@ mod download {
     use std::str::FromStr;
 
     use anyhow::Context;
-    use bitcoin_hashes::{sha256, Hash};
+    use bitcoin_hashes::sha256;
     use flate2::read::GzDecoder;
     use tar::Archive;
 

--- a/regtest/src/lib.rs
+++ b/regtest/src/lib.rs
@@ -112,8 +112,6 @@ pub enum P2P {
 
 /// All the possible error in this crate
 pub enum Error {
-    /// Wrapper of io Error
-    Io(std::io::Error),
     /// Wrapper of bitcoincore_rpc Error
     Rpc(client_sync::Error),
     /// Returned when calling methods requiring a feature to be activated, but it's not
@@ -141,7 +139,6 @@ impl fmt::Debug for Error {
         use Error::*;
 
         match self {
-            Io(_) => write!(f, "io::Error"), // FIXME: Use bitcoin-internals.
             Rpc(_) => write!(f, "bitcoin_rpc::Error"),
             NoFeature => write!(f, "Called a method requiring a feature to be set, but it's not"),
             NoEnvVar => write!(f, "Called a method requiring env var `BITCOIND_EXE` to be set, but it's not"),
@@ -164,7 +161,6 @@ impl std::error::Error for Error {
         use Error::*;
 
         match *self {
-            Error::Io(ref e) => Some(e),
             Error::Rpc(ref e) => Some(e),
             NoFeature
             | NoEnvVar
@@ -502,10 +498,6 @@ pub fn get_available_port() -> anyhow::Result<u16> {
     // using 0 as port let the system assign a port available
     let t = TcpListener::bind(("127.0.0.1", 0))?; // 0 means the OS choose a free port
     Ok(t.local_addr().map(|s| s.port())?)
-}
-
-impl From<std::io::Error> for Error {
-    fn from(e: std::io::Error) -> Self { Error::Io(e) }
 }
 
 impl From<client_sync::Error> for Error {


### PR DESCRIPTION
As we develop `primitives` it is useful to have crates using the changes to catch mistakes as we go. The crates in this repo are prime candidates for depending on `primitives` and not using `rust-bitcoin`.