### PR TITLE
Remove authors

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,12 +1,7 @@
 [package]
 name = "bitcoind-json-rpc-client"
 version = "0.3.0"
-authors = [
-    "Steven Roose <steven@stevenroose.org>",
-    "Jean Pierre Dudey <jeandudey@hotmail.com>",
-    "Dawid Ciężarkiewicz <dpc@dpc.pw>",
-    "Tobin C. Harding <me@tobin.cc>"
-]
+authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoind-json-rpc"
 description = "Bitcoin Core JSON-RPC client"

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,12 +1,7 @@
 [package]
 name = "bitcoind-json-rpc-types"
 version = "0.3.0"
-authors = [
-    "Steven Roose <steven@stevenroose.org>",
-    "Jean Pierre Dudey <jeandudey@hotmail.com>",
-    "Dawid Ciężarkiewicz <dpc@dpc.pw>",
-    "Tobin C. Harding <me@tobin.cc>"
-]
+authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoind-json-rpc"
 description = "Bitcoin Core JSON-RPC API types"


### PR DESCRIPTION
When this crate started out I copied a bunch of code from `rust-bitcoincore-rpc`, as such I kept the original authors. Since then I have re-started from scratch. The original authors should not be held accountable for this crate anymore.