### PR TITLE
Move macro call

### DIFF
--- a/integration_test/tests/v28_api.rs
+++ b/integration_test/tests/v28_api.rs
@@ -8,10 +8,10 @@ use integration_test::*;
 mod blockchain {
     use super::*;
 
-    impl_test_v17__getblockchaininfo!();
     impl_test_v17__getbestblockhash!();
     impl_test_v17__getblock_verbosity_0!();
     impl_test_v17__getblock_verbosity_1!();
+    impl_test_v17__getblockchaininfo!();
 }
 
 // == Control ==


### PR DESCRIPTION
During development of the v28 support we re-ordered some macro calls, so as not to hold up an external contributor with triviality I acked and merged as it was.

Put the macro calls in the same order so that when one diffs `v27_api.rs` and `v28_api.rs` there are no false positives in the diff.

Internal change only.