### PR TITLE
Archive the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,6 @@
-# `bitcoind` JSON-RPC support
+# ARCHIVED `bitcoind` JSON-RPC support
 
-There are two primary purposes of this repository.
+This repository has been archived because it was re-named (see issue
+#48). All development is now done at https://github.com/rust-bitcoin/corepc
 
-1. Provide the [`bitcoind-json-rpc-types`](https://crates.io/crates/bitcoind-json-rpc-types) crate
-   for use in production software.
-2. Provide tools to the community for integration testing code written in Rust that interacts with
-   the Bitcoin network. Primarily consumers of the [`rust-bitcoin`](https://crates.io/crates/bitcoin)
-   library. And enable doing so against multiple versions of Bitcoin Core.
-
-If you require a JSON RPC client in production software it is expected you write your own and only
-use the `bitcoind-json-rpc-types` crate in your dependency graph. Feel free to copy/steal/plagiarise
-or otherwise enjoy yourself with anything in this repository - no attribution required.
-
-**Please do not use `client` in production and raise bugs, issues, or feature requests.**
-
-## Crate listing
-
-- [`json`](https://crates.io/crates/bitcoind-json-rpc-types): Rust types returned by the JSON-RPC API of Bitcoin Core (`bitcoind-json-rpc-types`).
-- [`regtest`](https://crates.io/crates/bitcoind-json-rpc-regtest): Runs `bitcoind` regtest nodes.
-- [`client`](https://crates.io/crates/bitcoind-json-rpc-client): A blocking JSON-RPC client used to test `bitcoind-json-rpc-types`.
-- `integration_test`: Integration tests that use `client` and `regtest` to test `json`.
-
-## Original code
-
-I don't know who is using `bitcoind` and/or `rust-bitocincore-rpc` in the wild and I do not want to
-disrupt them. As such `bitcoind` was pulled in here with permission of the original author.
-
-Some code shamelessly stolen from `rust-bitcoincore-rpc` (credit to Steven).
-
-- [rust-bitcoincore-rpcv0.19.0](https://github.com/rust-bitcoin/rust-bitcoincore-rpc)
-- [`bitcoind`](https://crates.io/crates/bitcoind)
-
-## Minimum Supported Rust Version (MSRV)
-
-This library should always compile with any combination of features on **Rust 1.63.0**.
-
-Use `Cargo-minimal.lock` to build the MSRV by copying to `Cargo.lock` and building.
+So long and thanks for all the fish.


### PR DESCRIPTION
We renamed this repo and moved it. We released the 3 crates under the new name already. Filter crates.io using

https://crates.io/search?q=corepc

To move the repo I did the re-name manually by doing:

- Created a new repository in my github account tcharding/corepc
- Used `rsync` to move the code from here.
- Did the rename
- Did a PR to the repo to test CI (and fixed the bugs)
- Did a bunch of other improvements (eg fleshed out v17 and v18)
- Got github.com/rust-bitcoin/corepc repo created
- Got perms on that repo
- Added `upstream` remote to the repo
- Pushed to `upstream`
- Update README and (force) pushed to master

All future changes will go through the normal PR process now.